### PR TITLE
Moved verbose logging behind a option

### DIFF
--- a/Source/ED-EnhancedOptions/Patches/Patch.cs
+++ b/Source/ED-EnhancedOptions/Patches/Patch.cs
@@ -36,13 +36,22 @@ namespace EnhancedDevelopment.EnhancedOptions
 
             if (this.ShouldPatchApply())
             {
-                Log.Message(_LogLocation + "Applying Patch: " + this.PatchDescription());
+                if(Prefs.LogVerbose)
+                {
+                    Log.Message(_LogLocation + "Applying Patch: " + this.PatchDescription());                
+                }
                 this.ApplyPatch(harmony);
-                Log.Message(_LogLocation + "Applied Patch: " + this.PatchDescription());
+                if(Prefs.LogVerbose)
+                {
+                    Log.Message(_LogLocation + "Applied Patch: " + this.PatchDescription());
+                }
             }
             else
             {
-                Log.Message(_LogLocation + "Skipping Applying Patch: " + this.PatchDescription());
+                if(Prefs.LogVerbose)
+                {
+                    Log.Message(_LogLocation + "Skipping Applying Patch: " + this.PatchDescription());
+                }
             }
         }
 


### PR DESCRIPTION
Prefs.LogVerbose is a setting in devmode, available for those that really want a long and detailed log. For those that don't, this severely reduces the logspam on start up. Example: https://git.io/fNrrn -- try troubleshooting that.